### PR TITLE
merging attribute make crash(don't merging!)

### DIFF
--- a/data/core/macros/abilities.cfg
+++ b/data/core/macros/abilities.cfg
@@ -191,7 +191,7 @@ Adjacent own units of lower level will do more damage in battle. When a unit adj
         affect_self=no
         affect_allies=yes
         [filter_weapon]
-            wp_ability_id_active={ANIM}
+            special_id_active={ANIM}
         [/filter_weapon]
         [affect_adjacent]
         [/affect_adjacent]
@@ -209,7 +209,7 @@ Adjacent own units of lower level will do more damage in battle. When a unit adj
         add=0
         max_value=100
         [filter_second_weapon]
-            wp_ability_id_active={ANIM}
+            special_id_active={ANIM}
         [/filter_second_weapon]
         [affect_adjacent]
         [/affect_adjacent]

--- a/src/units/attack_type.cpp
+++ b/src/units/attack_type.cpp
@@ -182,7 +182,7 @@ static bool matches_simple_filter(const attack_type & attack, const config & fil
 	if(!filter_special_id_active.empty()) {
 		bool found = false;
 		for(auto& special : filter_special_id_active) {
-			if(attack.get_special_bool(special, false, true, false)) {
+			if(attack.bool_ability(special, false, true, false)) {
 				found = true;
 				break;
 			}
@@ -218,7 +218,7 @@ static bool matches_simple_filter(const attack_type & attack, const config & fil
 	if(!filter_special_type_active.empty()) {
 		bool found = false;
 		for(auto& special : filter_special_type_active) {
-			if(attack.get_special_bool(special, false, false)) {
+			if(attack.bool_ability(special, false, false)) {
 				found = true;
 				break;
 			}


### PR DESCRIPTION
in Httt, in debug mode, create Princess unit in side enemy of your side, an Elvish Champion to same side of Princess, and place the cursor on Champion and the game crah.

if instead to bool_ability, you mofify the name of attribute to special_ in abilities.cfg and atta_type.cpp , the leading_anim of Princess don't played when Champion is attacked.