### PR TITLE
add [filter_specials] and [filter_abilities]

### DIFF
--- a/data/campaigns/Heir_To_The_Throne/utils/abilities.cfg
+++ b/data/campaigns/Heir_To_The_Throne/utils/abilities.cfg
@@ -11,7 +11,7 @@
             [filter_weapon]
                 [not]
                     special_type_active=firststrike
-					special_only=yes
+                    special_only=yes
                 [/not]
             [/filter_weapon]
         [/filter_student]

--- a/data/campaigns/Heir_To_The_Throne/utils/abilities.cfg
+++ b/data/campaigns/Heir_To_The_Throne/utils/abilities.cfg
@@ -9,10 +9,11 @@
         affect_allies=yes
         [filter_student]
             [filter_weapon]
-                [not]
-                    special_type_active=firststrike
-                    exclude_tags=abilities
-                [/not]
+                [filter_specials]
+                    [not]
+                        special_type_active=firststrike
+                    [/not]
+                [/filter_specials]
             [/filter_weapon]
         [/filter_student]
         [filter_opponent]

--- a/data/campaigns/Heir_To_The_Throne/utils/abilities.cfg
+++ b/data/campaigns/Heir_To_The_Throne/utils/abilities.cfg
@@ -11,7 +11,7 @@
             [filter_weapon]
                 [not]
                     special_type_active=firststrike
-                    special_only=yes
+                    exclude_tags=specials
                 [/not]
             [/filter_weapon]
         [/filter_student]

--- a/data/campaigns/Heir_To_The_Throne/utils/abilities.cfg
+++ b/data/campaigns/Heir_To_The_Throne/utils/abilities.cfg
@@ -10,7 +10,8 @@
         [filter_student]
             [filter_weapon]
                 [not]
-                    special_type_active=firststrike #exclude [specials] for not activate ABILITY_LEADERSHIP_ANIM if an hallberdier fight
+                    special_type_active=firststrike
+					special_only=yes
                 [/not]
             [/filter_weapon]
         [/filter_student]

--- a/data/campaigns/Heir_To_The_Throne/utils/abilities.cfg
+++ b/data/campaigns/Heir_To_The_Throne/utils/abilities.cfg
@@ -11,7 +11,7 @@
             [filter_weapon]
                 [not]
                     special_type_active=firststrike
-                    exclude_tags=specials
+                    exclude_tags=abilities
                 [/not]
             [/filter_weapon]
         [/filter_student]

--- a/data/core/macros/abilities.cfg
+++ b/data/core/macros/abilities.cfg
@@ -211,6 +211,7 @@ Adjacent own units of lower level will do more damage in battle. When a unit adj
         max_value=100
         [filter_second_weapon]
             special_id_active={ANIM}
+            exclude_tags=specials
         [/filter_second_weapon]
         [affect_adjacent]
         [/affect_adjacent]

--- a/data/core/macros/abilities.cfg
+++ b/data/core/macros/abilities.cfg
@@ -192,7 +192,6 @@ Adjacent own units of lower level will do more damage in battle. When a unit adj
         affect_allies=yes
         [filter_weapon]
             special_id_active={ANIM}
-            exclude_tags=specials
         [/filter_weapon]
         [affect_adjacent]
         [/affect_adjacent]
@@ -211,7 +210,6 @@ Adjacent own units of lower level will do more damage in battle. When a unit adj
         max_value=100
         [filter_second_weapon]
             special_id_active={ANIM}
-            exclude_tags=specials
         [/filter_second_weapon]
         [affect_adjacent]
         [/affect_adjacent]

--- a/data/core/macros/abilities.cfg
+++ b/data/core/macros/abilities.cfg
@@ -192,6 +192,7 @@ Adjacent own units of lower level will do more damage in battle. When a unit adj
         affect_allies=yes
         [filter_weapon]
             special_id_active={ANIM}
+            exclude_tags=specials
         [/filter_weapon]
         [affect_adjacent]
         [/affect_adjacent]

--- a/data/core/macros/abilities.cfg
+++ b/data/core/macros/abilities.cfg
@@ -192,7 +192,6 @@ Adjacent own units of lower level will do more damage in battle. When a unit adj
         affect_allies=yes
         [filter_weapon]
             special_id_active={ANIM}
-            ability_only=yes
         [/filter_weapon]
         [affect_adjacent]
         [/affect_adjacent]
@@ -211,7 +210,6 @@ Adjacent own units of lower level will do more damage in battle. When a unit adj
         max_value=100
         [filter_second_weapon]
             special_id_active={ANIM}
-            ability_only=yes
         [/filter_second_weapon]
         [affect_adjacent]
         [/affect_adjacent]

--- a/data/core/macros/abilities.cfg
+++ b/data/core/macros/abilities.cfg
@@ -191,7 +191,8 @@ Adjacent own units of lower level will do more damage in battle. When a unit adj
         affect_self=no
         affect_allies=yes
         [filter_weapon]
-            wp_ability_id_active={ANIM}
+            special_id_active={ANIM}
+            ability_only=yes
         [/filter_weapon]
         [affect_adjacent]
         [/affect_adjacent]
@@ -209,7 +210,8 @@ Adjacent own units of lower level will do more damage in battle. When a unit adj
         add=0
         max_value=100
         [filter_second_weapon]
-            wp_ability_id_active={ANIM}
+            special_id_active={ANIM}
+            ability_only=yes
         [/filter_second_weapon]
         [affect_adjacent]
         [/affect_adjacent]

--- a/data/schema/filters/weapon.cfg
+++ b/data/schema/filters/weapon.cfg
@@ -9,10 +9,10 @@
 	{SIMPLE_KEY special_active string_list}
 	{SIMPLE_KEY special_id string_list}
 	{SIMPLE_KEY special_id_active string_list}
-	{SIMPLE_KEY wp_ability_id_active string_list}
 	{SIMPLE_KEY special_type string_list}
 	{SIMPLE_KEY special_type_active string_list}
-	{SIMPLE_KEY wp_ability_type_active string_list}
+    {SIMPLE_KEY ability_only bool}
+	{SIMPLE_KEY special_only bool}
 	{SIMPLE_KEY formula formula}
 	{SIMPLE_KEY damage s_range_list}
 	{SIMPLE_KEY number s_range_list}

--- a/data/schema/filters/weapon.cfg
+++ b/data/schema/filters/weapon.cfg
@@ -11,8 +11,7 @@
 	{SIMPLE_KEY special_id_active string_list}
 	{SIMPLE_KEY special_type string_list}
 	{SIMPLE_KEY special_type_active string_list}
-	{SIMPLE_KEY ability_only bool}
-	{SIMPLE_KEY special_only bool}
+	{DEFAULT_KEY exclude_tags weapon_apply none}
 	{SIMPLE_KEY formula formula}
 	{SIMPLE_KEY damage s_range_list}
 	{SIMPLE_KEY number s_range_list}

--- a/data/schema/filters/weapon.cfg
+++ b/data/schema/filters/weapon.cfg
@@ -11,13 +11,30 @@
 	{SIMPLE_KEY special_id_active string_list}
 	{SIMPLE_KEY special_type string_list}
 	{SIMPLE_KEY special_type_active string_list}
-	{DEFAULT_KEY exclude_tags weapon_apply none}
+	{FILTER_TAG "filter_abilities" weapon ()}
+	{FILTER_TAG "filter_specials" weapon ()}
 	{SIMPLE_KEY formula formula}
 	{SIMPLE_KEY damage s_range_list}
 	{SIMPLE_KEY number s_range_list}
 	{SIMPLE_KEY parry s_range_list}
 	{SIMPLE_KEY accuracy s_range_list}
 	{SIMPLE_KEY movement_used s_range_list}
+	{FILTER_BOOLEAN_OPS weapon}
+[/tag]
+
+[tag]
+	name="$filter_abilities"
+	max=0
+	{SIMPLE_KEY special_id_active string_list}
+	{SIMPLE_KEY special_type_active string_list}
+	{FILTER_BOOLEAN_OPS weapon}
+[/tag]
+
+[tag]
+	name="$filter_specials"
+	max=0
+	{SIMPLE_KEY special_id_active string_list}
+	{SIMPLE_KEY special_type_active string_list}
 	{FILTER_BOOLEAN_OPS weapon}
 [/tag]
 

--- a/data/schema/filters/weapon.cfg
+++ b/data/schema/filters/weapon.cfg
@@ -11,7 +11,7 @@
 	{SIMPLE_KEY special_id_active string_list}
 	{SIMPLE_KEY special_type string_list}
 	{SIMPLE_KEY special_type_active string_list}
-    {SIMPLE_KEY ability_only bool}
+	{SIMPLE_KEY ability_only bool}
 	{SIMPLE_KEY special_only bool}
 	{SIMPLE_KEY formula formula}
 	{SIMPLE_KEY damage s_range_list}

--- a/data/schema/game_config.cfg
+++ b/data/schema/game_config.cfg
@@ -37,6 +37,10 @@
         value="self|opponent|attacker|defender|both"
     [/type]
     [type]
+        name="weapon_apply"
+        value="none|abilities|specials"
+    [/type]
+    [type]
         name="addon_type"
         value="sp|mp|hybrid"
     [/type]

--- a/data/schema/game_config.cfg
+++ b/data/schema/game_config.cfg
@@ -37,10 +37,6 @@
         value="self|opponent|attacker|defender|both"
     [/type]
     [type]
-        name="weapon_apply"
-        value="none|abilities|specials"
-    [/type]
-    [type]
         name="addon_type"
         value="sp|mp|hybrid"
     [/type]

--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -1271,9 +1271,17 @@ unit_ability_list attack_type::impl_check_abilities(const std::string& special, 
 	return abil_list;
 }
 
-bool attack_type::bool_ability(const std::string& ability, bool simple_check, bool special_id, bool special_tags) const
+bool attack_type::bool_ability(const std::string& ability, bool simple_check, bool special_id, bool special_tags, bool ability_only, bool special_only) const
 {
-	return (get_special_bool(ability, simple_check, special_id, special_tags) || get_special_ability_bool(ability, special_id, special_tags));
+	if((!ability_only && !special_only) || (ability_only && special_only)){
+		return (get_special_bool(name, simple_check, special_id, special_tags) || get_special_ability_bool(name, special_id, special_tags));
+	}
+	else if(ability_only && !special_only){
+		return get_special_ability_bool(name, special_id, special_tags);
+	}
+	else if(!ability_only && special_only){
+		return get_special_bool(name, simple_check, special_id, special_tags);
+	}
 }
 //end of emulate weapon special functions.
 

--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -1271,7 +1271,7 @@ unit_ability_list attack_type::impl_check_abilities(const std::string& special, 
 	return abil_list;
 }
 
-bool attack_type::bool_ability(const std::string& ability, bool simple_check, bool special_id, bool special_tags, bool ability_only, bool special_only) const
+bool attack_type::bool_ability(const std::string& ability, bool simple_check, bool special_id, bool special_tags) const
 {
 	return (get_special_bool(name, simple_check, special_id, special_tags) || get_special_ability_bool(name, special_id, special_tags));
 }

--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -1273,7 +1273,7 @@ unit_ability_list attack_type::impl_check_abilities(const std::string& special, 
 
 bool attack_type::bool_ability(const std::string& ability, bool simple_check, bool special_id, bool special_tags) const
 {
-	return (get_special_bool(name, simple_check, special_id, special_tags) || get_special_ability_bool(name, special_id, special_tags));
+	return (get_special_bool(ability, simple_check, special_id, special_tags) || get_special_ability_bool(ability, special_id, special_tags));
 }
 //end of emulate weapon special functions.
 

--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -1271,17 +1271,9 @@ unit_ability_list attack_type::impl_check_abilities(const std::string& special, 
 	return abil_list;
 }
 
-bool attack_type::bool_ability(const std::string& ability, bool simple_check, bool special_id, bool special_tags, bool ability_only, bool special_only) const
+bool attack_type::bool_ability(const std::string& ability, bool simple_check, bool special_id, bool special_tags) const
 {
-	if((!ability_only && !special_only) || (ability_only && special_only)){
-		return (get_special_bool(name, simple_check, special_id, special_tags) || get_special_ability_bool(name, special_id, special_tags));
-	}
-	else if(ability_only && !special_only){
-		return get_special_ability_bool(name, special_id, special_tags);
-	}
-	else if(!ability_only && special_only){
-		return get_special_bool(name, simple_check, special_id, special_tags);
-	}
+	return (get_special_bool(name, simple_check, special_id, special_tags) || get_special_ability_bool(name, special_id, special_tags));
 }
 //end of emulate weapon special functions.
 

--- a/src/units/attack_type.cpp
+++ b/src/units/attack_type.cpp
@@ -92,6 +92,29 @@ std::string attack_type::accuracy_parry_description() const
 	return s.str();
 }
 
+static bool exclude_abilities(const config& filter)
+{
+	const std::string& exclude_tags = filter["exclude_tags"];
+	if ( exclude_tags.empty() )
+		return false;
+	if ( exclude_tags == "none" )
+		return false;
+	if ( exclude_tags == "abilities" )
+		return true;
+	return false;
+}
+
+static bool exclude_special(const config& filter)
+{
+	const std::string& exclude_tags = filter["exclude_tags"];
+	if ( exclude_tags.empty() )
+		return false;
+	if ( exclude_tags == "none" )
+		return false;
+	if ( exclude_tags == "specials" )
+		return true;
+	return false;
+}
 /**
  * Returns whether or not *this matches the given @a filter, ignoring the
  * complexities introduced by [and], [or], and [not].
@@ -112,8 +135,8 @@ static bool matches_simple_filter(const attack_type & attack, const config & fil
 	const std::vector<std::string> filter_special_active = utils::split(filter["special_active"]);
 	const std::vector<std::string> filter_special_id_active = utils::split(filter["special_id_active"]);
 	const std::vector<std::string> filter_special_type_active = utils::split(filter["special_type_active"]);
-	bool filter_ability_only = filter["ability_only"].to_bool(false);
-	bool filter_special_only = filter["special_only"].to_bool(false);
+	bool filter_ability_only = exclude_abilities(filter);
+	bool filter_special_only = exclude_special(filter);
 	const std::string filter_formula = filter["formula"];
 
 	if ( !filter_range.empty() && std::find(filter_range.begin(), filter_range.end(), attack.range()) == filter_range.end() )

--- a/src/units/attack_type.cpp
+++ b/src/units/attack_type.cpp
@@ -182,27 +182,9 @@ static bool matches_simple_filter(const attack_type & attack, const config & fil
 	if(!filter_special_id_active.empty()) {
 		bool found = false;
 		for(auto& special : filter_special_id_active) {
-			if(filter_ability_only && filter_special_only){
-				filter_ability_only = false;
-				filter_special_only =false;
-			}
-			if(!filter_ability_only && filter_special_only){
-				if(attack.get_special_bool(special, false, true, false)) {
-					found = true;
-					break;
-				}
-			}
-			if(filter_ability_only && !filter_special_only){
-				if(attack.get_special_ability_bool(special, true, false)) {
-					found = true;
-					break;
-				}
-			}
-			if(!filter_ability_only && !filter_special_only){
-				if(attack.bool_ability(special, false, true, false)) {
-					found = true;
-					break;
-				}
+			if(attack.bool_ability(special, false, true, false, filter_ability_only, filter_special_only)) {
+				found = true;
+				break;
 			}
 		}
 		if(!found) {
@@ -224,27 +206,9 @@ static bool matches_simple_filter(const attack_type & attack, const config & fil
 	if(!filter_special_type_active.empty()) {
 		bool found = false;
 		for(auto& special : filter_special_type_active) {
-			if(filter_ability_only && filter_special_only){
-				filter_ability_only = false;
-				filter_special_only =false;
-			}
-			if(!filter_ability_only && filter_special_only){
-				if(attack.get_special_bool(special, false, false)) {
-					found = true;
-					break;
-				}
-			}
-			if(filter_ability_only && !filter_special_only){
-				if(attack.get_special_ability_bool(special, false)) {
-					found = true;
-					break;
-				}
-			}
-			if(!filter_ability_only && !filter_special_only){
-				if(attack.bool_ability(special, false, false)) {
-					found = true;
-					break;
-				}
+			if(attack.bool_ability(special, false, false, true, filter_ability_only, filter_special_only)) {
+				found = true;
+				break;
 			}
 		}
 		if(!found) {

--- a/src/units/attack_type.cpp
+++ b/src/units/attack_type.cpp
@@ -144,12 +144,12 @@ static bool matches_simple_filter(const attack_type & attack, const config & fil
 	const config & filter_specials = filter.child("filter_specials");
 	const config & filter_abilities = filter.child("filter_abilities");
 	if ( filter_specials ){
-	const std::vector<std::string> filter_specials_id_active = utils::split(filter_specials["special_id_active"]);
-	const std::vector<std::string> filter_specials_type_active = utils::split(filter_specials["special_type_active"]);
+		const std::vector<std::string> filter_specials_id_active = utils::split(filter_specials["special_id_active"]);
+		const std::vector<std::string> filter_specials_type_active = utils::split(filter_specials["special_type_active"]);
 	}
 	if ( filter_abilities ){
-	const std::vector<std::string> filter_abilities_id_active = utils::split(filter_abilities["special_id_active"]);
-	const std::vector<std::string> filter_abilities_type_active = utils::split(filter_abilities["special_type_active"]);
+		const std::vector<std::string> filter_abilities_id_active = utils::split(filter_abilities["special_id_active"]);
+		const std::vector<std::string> filter_abilities_type_active = utils::split(filter_abilities["special_type_active"]);
 	}
 	const std::string filter_formula = filter["formula"];
 

--- a/src/units/attack_type.cpp
+++ b/src/units/attack_type.cpp
@@ -92,31 +92,6 @@ std::string attack_type::accuracy_parry_description() const
 	return s.str();
 }
 
-namespace {
-	bool exclude_abilities(const config& filter)
-	{
-		const std::string& exclude_tags = filter["exclude_tags"];
-		if ( exclude_tags.empty() )
-			return false;
-		if ( exclude_tags == "none" )
-			return false;
-		if ( exclude_tags == "abilities" )
-			return true;
-		return false;
-	}
-
-	bool exclude_special(const config& filter)
-	{
-		const std::string& exclude_tags = filter["exclude_tags"];
-		if ( exclude_tags.empty() )
-			return false;
-		if ( exclude_tags == "none" )
-			return false;
-		if ( exclude_tags == "specials" )
-			return true;
-		return false;
-	}
-}
 /**
  * Returns whether or not *this matches the given @a filter, ignoring the
  * complexities introduced by [and], [or], and [not].
@@ -137,8 +112,20 @@ static bool matches_simple_filter(const attack_type & attack, const config & fil
 	const std::vector<std::string> filter_special_active = utils::split(filter["special_active"]);
 	const std::vector<std::string> filter_special_id_active = utils::split(filter["special_id_active"]);
 	const std::vector<std::string> filter_special_type_active = utils::split(filter["special_type_active"]);
-	bool filter_ability_only = exclude_special(filter);
-	bool filter_special_only = exclude_abilities(filter);
+	const std::vector<std::string> filter_specials_id_active;
+	const std::vector<std::string> filter_specials_type_active;
+	const std::vector<std::string> filter_abilities_id_active;
+	const std::vector<std::string> filter_abilities_type_active;
+	const config & filter_specials = filter.child("filter_specials");
+	const config & filter_abilities = filter.child("filter_abilities");
+	if ( filter_specials ){
+	const std::vector<std::string> filter_specials_id_active = utils::split(filter_specials["special_id_active"]);
+	const std::vector<std::string> filter_specials_type_active = utils::split(filter_specials["special_type_active"]);
+	}
+	if ( filter_abilities ){
+	const std::vector<std::string> filter_abilities_id_active = utils::split(filter_abilities["special_id_active"]);
+	const std::vector<std::string> filter_abilities_type_active = utils::split(filter_abilities["special_type_active"]);
+	}
 	const std::string filter_formula = filter["formula"];
 
 	if ( !filter_range.empty() && std::find(filter_range.begin(), filter_range.end(), attack.range()) == filter_range.end() )
@@ -207,8 +194,32 @@ static bool matches_simple_filter(const attack_type & attack, const config & fil
 	if(!filter_special_id_active.empty()) {
 		bool found = false;
 		for(auto& special : filter_special_id_active) {
-			if(attack.bool_ability(special, false, true, false, filter_ability_only, filter_special_only)) {
+            if(attack.bool_ability(special, false, true, false)) {
+  				found = true;
+				break;
+            }
+		}
+		if(!found) {
+			return false;
+		}
+	}
+	if(!filter_specials_id_active.empty()) {
+		bool found = false;
+		for(auto& special : filter_specials_id_active) {
+			if(attack.get_special_bool(special, false, true, false)) {
 				found = true;
+				break;
+			}
+		}
+		if(!found) {
+			return false;
+		}
+	}
+	if(!filter_abilities_id_active.empty()) {
+		bool found = false;
+		for(auto& special : filter_abilities_id_active) {
+			if(attack.get_special_ability_bool(special, true, false)) {
+  				found = true;
 				break;
 			}
 		}
@@ -231,10 +242,34 @@ static bool matches_simple_filter(const attack_type & attack, const config & fil
 	if(!filter_special_type_active.empty()) {
 		bool found = false;
 		for(auto& special : filter_special_type_active) {
-			if(attack.bool_ability(special, false, false, true, filter_ability_only, filter_special_only)) {
+		    if(attack.bool_ability(special, false, false)) {
 				found = true;
 				break;
-			}
+		    }
+		}
+		if(!found) {
+			return false;
+		}
+	}
+	if(!filter_specials_type_active.empty()) {
+		bool found = false;
+		for(auto& special : filter_specials_type_active) {
+		    if(attack.get_special_bool(special, false, false)) {
+				found = true;
+				break;
+		    }
+		}
+		if(!found) {
+			return false;
+		}
+	}
+	if(!filter_abilities_type_active.empty()) {
+		bool found = false;
+		for(auto& special : filter_abilities_type_active) {
+		    if(attack.get_special_ability_bool(special, false)) {
+				found = true;
+				break;
+		    }
 		}
 		if(!found) {
 			return false;

--- a/src/units/attack_type.cpp
+++ b/src/units/attack_type.cpp
@@ -92,28 +92,30 @@ std::string attack_type::accuracy_parry_description() const
 	return s.str();
 }
 
-static bool exclude_abilities(const config& filter)
-{
-	const std::string& exclude_tags = filter["exclude_tags"];
-	if ( exclude_tags.empty() )
+namespace {
+	bool exclude_abilities(const config& filter)
+	{
+		const std::string& exclude_tags = filter["exclude_tags"];
+		if ( exclude_tags.empty() )
+			return false;
+		if ( exclude_tags == "none" )
+			return false;
+		if ( exclude_tags == "abilities" )
+			return true;
 		return false;
-	if ( exclude_tags == "none" )
-		return false;
-	if ( exclude_tags == "abilities" )
-		return true;
-	return false;
-}
+	}
 
-static bool exclude_special(const config& filter)
-{
-	const std::string& exclude_tags = filter["exclude_tags"];
-	if ( exclude_tags.empty() )
+	bool exclude_special(const config& filter)
+	{
+		const std::string& exclude_tags = filter["exclude_tags"];
+		if ( exclude_tags.empty() )
+			return false;
+		if ( exclude_tags == "none" )
+			return false;
+		if ( exclude_tags == "specials" )
+			return true;
 		return false;
-	if ( exclude_tags == "none" )
-		return false;
-	if ( exclude_tags == "specials" )
-		return true;
-	return false;
+	}
 }
 /**
  * Returns whether or not *this matches the given @a filter, ignoring the
@@ -135,8 +137,8 @@ static bool matches_simple_filter(const attack_type & attack, const config & fil
 	const std::vector<std::string> filter_special_active = utils::split(filter["special_active"]);
 	const std::vector<std::string> filter_special_id_active = utils::split(filter["special_id_active"]);
 	const std::vector<std::string> filter_special_type_active = utils::split(filter["special_type_active"]);
-	bool filter_ability_only = exclude_abilities(filter);
-	bool filter_special_only = exclude_special(filter);
+	bool filter_ability_only = exclude_special(filter);
+	bool filter_special_only = exclude_abilities(filter);
 	const std::string filter_formula = filter["formula"];
 
 	if ( !filter_range.empty() && std::find(filter_range.begin(), filter_range.end(), attack.range()) == filter_range.end() )

--- a/src/units/attack_type.cpp
+++ b/src/units/attack_type.cpp
@@ -219,10 +219,10 @@ static bool matches_simple_filter(const attack_type & attack, const config & fil
 	if(!filter_special_id_active.empty()) {
 		bool found = false;
 		for(auto& special : filter_special_id_active) {
-      if(attack.bool_ability(special, false, true, false)) {
-        found = true;
-        break;
-      }
+			if(attack.bool_ability(special, false, true, false)) {
+				found = true;
+				break;
+			}
 		}
 		if(!found) {
 			return false;
@@ -243,9 +243,9 @@ static bool matches_simple_filter(const attack_type & attack, const config & fil
 	if(!filter_abilities_id_active.empty()) {
 		bool found = false;
 		for(auto& special : filter_abilities_id_active) {
-      if(attack.get_special_ability_bool(special, true, false)) {
-        found = true;
-        break;
+			if(attack.get_special_ability_bool(special, true, false)) {
+				found = true;
+				break;
 			}
 		}
 		if(!found) {
@@ -267,10 +267,10 @@ static bool matches_simple_filter(const attack_type & attack, const config & fil
 	if(!filter_special_type_active.empty()) {
 		bool found = false;
 		for(auto& special : filter_special_type_active) {
-      if(attack.bool_ability(special, false, false)) {
-        found = true;
+			if(attack.bool_ability(special, false, false)) {
+				found = true;
 				break;
-      }
+			}
 		}
 		if(!found) {
 			return false;
@@ -279,10 +279,10 @@ static bool matches_simple_filter(const attack_type & attack, const config & fil
 	if(!filter_specials_type_active.empty()) {
 		bool found = false;
 		for(auto& special : filter_specials_type_active) {
-      if(attack.get_special_bool(special, false, false)) {
-        found = true;
+			if(attack.get_special_bool(special, false, false)) {
+				found = true;
 				break;
-      }
+			}
 		}
 		if(!found) {
 			return false;
@@ -291,10 +291,10 @@ static bool matches_simple_filter(const attack_type & attack, const config & fil
 	if(!filter_abilities_type_active.empty()) {
 		bool found = false;
 		for(auto& special : filter_abilities_type_active) {
-      if(attack.get_special_ability_bool(special, false)) {
-        found = true;
+			if(attack.get_special_ability_bool(special, false)) {
+				found = true;
 				break;
-      }
+			}
 		}
 		if(!found) {
 			return false;

--- a/src/units/attack_type.cpp
+++ b/src/units/attack_type.cpp
@@ -92,31 +92,6 @@ std::string attack_type::accuracy_parry_description() const
 	return s.str();
 }
 
-namespace {
-	bool exclude_abilities(const config& filter)
-	{
-		const std::string& exclude_tags = filter["exclude_tags"];
-		if ( exclude_tags.empty() )
-			return false;
-		if ( exclude_tags == "none" )
-			return false;
-		if ( exclude_tags == "abilities" )
-			return true;
-		return false;
-	}
-
-	bool exclude_special(const config& filter)
-	{
-		const std::string& exclude_tags = filter["exclude_tags"];
-		if ( exclude_tags.empty() )
-			return false;
-		if ( exclude_tags == "none" )
-			return false;
-		if ( exclude_tags == "specials" )
-			return true;
-		return false;
-	}
-}
 /**
  * Returns whether or not *this matches the given @a filter, ignoring the
  * complexities introduced by [and], [or], and [not].

--- a/src/units/attack_type.cpp
+++ b/src/units/attack_type.cpp
@@ -112,8 +112,8 @@ static bool matches_simple_filter(const attack_type & attack, const config & fil
 	const std::vector<std::string> filter_special_active = utils::split(filter["special_active"]);
 	const std::vector<std::string> filter_special_id_active = utils::split(filter["special_id_active"]);
 	const std::vector<std::string> filter_special_type_active = utils::split(filter["special_type_active"]);
-	const std::vector<std::string> filter_ability_id_active = utils::split(filter["wp_ability_id_active"]);
-	const std::vector<std::string> filter_ability_type_active = utils::split(filter["wp_ability_type_active"]);
+	bool filter_ability_only = filter["ability_only"].to_bool(false);
+	bool filter_special_only = filter["special_only"].to_bool(false);
 	const std::string filter_formula = filter["formula"];
 
 	if ( !filter_range.empty() && std::find(filter_range.begin(), filter_range.end(), attack.range()) == filter_range.end() )
@@ -182,21 +182,27 @@ static bool matches_simple_filter(const attack_type & attack, const config & fil
 	if(!filter_special_id_active.empty()) {
 		bool found = false;
 		for(auto& special : filter_special_id_active) {
-			if(attack.get_special_bool(special, false, true, false)) {
-				found = true;
-				break;
+			if(filter_ability_only && filter_special_only){
+				filter_ability_only = false;
+				filter_special_only =false;
 			}
-		}
-		if(!found) {
-			return false;
-		}
-	}
-	if(!filter_ability_id_active.empty()) {
-		bool found = false;
-		for(auto& special : filter_ability_id_active) {
-			if(attack.get_special_ability_bool(special, true, false)) {
-				found = true;
-				break;
+			if(!filter_ability_only && filter_special_only){
+				if(attack.get_special_bool(special, false, true, false)) {
+					found = true;
+					break;
+				}
+			}
+			if(filter_ability_only && !filter_special_only){
+				if(attack.get_special_ability_bool(special, true, false)) {
+					found = true;
+					break;
+				}
+			}
+			if(!filter_ability_only && !filter_special_only){
+				if(attack.bool_ability(special, false, true, false)) {
+					found = true;
+					break;
+				}
 			}
 		}
 		if(!found) {
@@ -218,21 +224,27 @@ static bool matches_simple_filter(const attack_type & attack, const config & fil
 	if(!filter_special_type_active.empty()) {
 		bool found = false;
 		for(auto& special : filter_special_type_active) {
-			if(attack.get_special_bool(special, false, false)) {
-				found = true;
-				break;
+			if(filter_ability_only && filter_special_only){
+				filter_ability_only = false;
+				filter_special_only =false;
 			}
-		}
-		if(!found) {
-			return false;
-		}
-	}
-	if(!filter_ability_type_active.empty()) {
-		bool found = false;
-		for(auto& special : filter_ability_type_active) {
-			if(attack.get_special_ability_bool(special, false)) {
-				found = true;
-				break;
+			if(!filter_ability_only && filter_special_only){
+				if(attack.get_special_bool(special, false, false)) {
+					found = true;
+					break;
+				}
+			}
+			if(filter_ability_only && !filter_special_only){
+				if(attack.get_special_ability_bool(special, false)) {
+					found = true;
+					break;
+				}
+			}
+			if(!filter_ability_only && !filter_special_only){
+				if(attack.bool_ability(special, false, false)) {
+					found = true;
+					break;
+				}
 			}
 		}
 		if(!found) {

--- a/src/units/attack_type.hpp
+++ b/src/units/attack_type.hpp
@@ -91,7 +91,7 @@ public:
 	unit_ability_list get_special_ability(const std::string& ability) const;
 	///return an boolean value for abilities like poison slow firstrike or petrifies
 	bool get_special_ability_bool(const std::string& special, bool special_id=true, bool special_tags=true) const;
-	bool bool_ability(const std::string& ability, bool simple_check=false, bool special_id=true, bool special_tags=true) const;
+	bool bool_ability(const std::string& ability, bool simple_check=false, bool special_id=true, bool special_tags=true, bool ability_only=false, bool special_only=false) const;
 
 	// In unit_types.cpp:
 

--- a/src/units/attack_type.hpp
+++ b/src/units/attack_type.hpp
@@ -91,7 +91,7 @@ public:
 	unit_ability_list get_special_ability(const std::string& ability) const;
 	///return an boolean value for abilities like poison slow firstrike or petrifies
 	bool get_special_ability_bool(const std::string& special, bool special_id=true, bool special_tags=true) const;
-	bool bool_ability(const std::string& ability, bool simple_check=false, bool special_id=true, bool special_tags=true, bool ability_only=false, bool special_only=false) const;
+	bool bool_ability(const std::string& ability, bool simple_check=false, bool special_id=true, bool special_tags=true) const;
 
 	// In unit_types.cpp:
 


### PR DESCRIPTION
For could make difference with abilities or specials like when type or id filtered are identical, these filter could be used.
If not used, then both will be filtered by default.

A potential usecase will be a weapon special who can affect enemy under aura abilitie, but not an unit with a specials similar, and the type and id are identical(weapon like charge)( extreme case!), discriminate specials and abilities weapon will be useful.

I have alos my usecase of leadership used for call leading_anim for another abilites(initiative) and i don't want anim called by use of regular firstrike or all specials of firstrike type, in that case discriminate by id is impossible and using discrimination by [specials tags is necessary.