### PR TITLE
remove weapon_anim tags

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -17,7 +17,6 @@
  ### WML Engine
    * Extent 'special_id_active' and 'special_type_active' to abilities used like weapon.
    * abilities used like weapon can call [leading_anim] now.
-   * add a [weapon_anim] for call [leading_anim] in some cases
  ### Miscellaneous and Bug Fixes
 
 ## Version 1.15.9

--- a/data/campaigns/Heir_To_The_Throne/utils/abilities.cfg
+++ b/data/campaigns/Heir_To_The_Throne/utils/abilities.cfg
@@ -15,7 +15,7 @@
         [affect_adjacent]
         [/affect_adjacent]
     [/firststrike]
-    [weapon_anim]
+    [firststrike]
         id=anim_firststrike#this weapon is used for call [leading_anim] instead instead of inititiative, for what animation was played in defense and with initiative active only
         affect_self=no
         affect_allies=yes
@@ -27,7 +27,7 @@
         [/filter_student]
         [affect_adjacent]
         [/affect_adjacent]
-    [/weapon_anim]
+    [/firststrike]
 #enddef
 
 #define NOTE_INITIATIVE

--- a/data/schema/units/abilities.cfg
+++ b/data/schema/units/abilities.cfg
@@ -133,7 +133,6 @@
 {BASED_ON_SPECIAL "poison"}
 {BASED_ON_SPECIAL "slow"}
 {BASED_ON_SPECIAL "petrifies"}
-{BASED_ON_SPECIAL "weapon_anim"}
 [tag]
 	name="*"
 	max=infinite

--- a/data/schema/units/specials.cfg
+++ b/data/schema/units/specials.cfg
@@ -41,11 +41,6 @@
 	super="units/unit_type/attack/specials/~generic~"
 [/tag]
 [tag]
-	name="weapon_anim"
-	max=infinite
-	super="units/unit_type/attack/specials/~generic~"
-[/tag]
-[tag]
 	# Using invalid characters to ensure it doesn't match a real tag.
 	name="~value~"
 	max=0

--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -1219,7 +1219,7 @@ bool attack_type::get_special_ability_bool(const std::string& special, bool spec
 {
 	const unit_map& units = display::get_singleton()->get_units();
 	assert(display::get_singleton());
-	static std::set<std::string> included_tags{"leadership", "resistance", "damage", "chance_to_hit", "berserk", "swarm", "drains", "heal_on_hit", "plague", "slow", "petrifies", "firststrike", "poison", "weapon_anim"};
+	static std::set<std::string> included_tags{"leadership", "resistance", "damage", "chance_to_hit", "berserk", "swarm", "drains", "heal_on_hit", "plague", "slow", "petrifies", "firststrike", "poison"};
 	if(self_){
 		std::vector<special_match> special_tag_matches;
 		std::vector<special_match> special_id_matches;

--- a/src/units/udisplay.cpp
+++ b/src/units/udisplay.cpp
@@ -657,7 +657,7 @@ void unit_attack(display * disp, game_board & board,
 
 	animator.add_animation(defender.shared_from_this(), defender_anim, def->get_location(), true, text, {255, 0, 0});
 
-	const std::vector<std::string> leader_tags{"leadership", "damage", "chance_to_hit", "berserk", "swarm", "drains", "heal_on_hit", "plague", "slow", "petrifies", "firststrike", "poison", "weapon_anim"};
+	const std::vector<std::string> leader_tags{"leadership", "damage", "chance_to_hit", "berserk", "swarm", "drains", "heal_on_hit", "plague", "slow", "petrifies", "firststrike", "poison"};
 	if(!leader_tags.empty()) {
 		for(auto& special : leader_tags) {
 			unit_ability_list abilities(att->get_location());
@@ -735,7 +735,7 @@ void reset_helpers(const unit *attacker,const unit *defender)
 	display* disp = display::get_singleton();
 	const unit_map& units = disp->get_units();
 	if(attacker) {
-		const std::vector<std::string> leader_tags{"leadership", "damage", "chance_to_hit", "berserk", "swarm", "drains", "heal_on_hit", "plague", "slow", "petrifies", "firststrike", "poison", "weapon_anim"};
+		const std::vector<std::string> leader_tags{"leadership", "damage", "chance_to_hit", "berserk", "swarm", "drains", "heal_on_hit", "plague", "slow", "petrifies", "firststrike", "poison"};
 		if(!leader_tags.empty()) {
 			for(auto& special : leader_tags) {
 				for(const unit_ability& ability : attacker->get_abilities(special)) {
@@ -750,7 +750,7 @@ void reset_helpers(const unit *attacker,const unit *defender)
 
 
 	if(defender) {
-		const std::vector<std::string> helper_tags{"resistance", "damage", "chance_to_hit", "berserk", "swarm", "drains", "heal_on_hit", "plague", "slow", "petrifies", "firststrike", "poison", "weapon_anim"};
+		const std::vector<std::string> helper_tags{"resistance", "damage", "chance_to_hit", "berserk", "swarm", "drains", "heal_on_hit", "plague", "slow", "petrifies", "firststrike", "poison"};
 		if(!helper_tags.empty()) {
 			for(auto& special : helper_tags) {
 				for(const unit_ability& ability : defender->get_abilities(special)) {


### PR DESCRIPTION
Now what get_special_ability_bool work perfectly and can filter many ability specials of same tags in same unit_type anim_weapon is unuse