### PR TITLE
pull a mofified version of calling leading_anim by abilities

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -16,6 +16,7 @@
  ### User interface
  ### WML Engine
    * Extent 'special_id_active' and 'special_type_active' to abilities used like weapon and to [leadership] abilities.
+   * abilities used like weapon can call [leading_anim] now.
  ### Miscellaneous and Bug Fixes
 
 ## Version 1.15.9

--- a/data/campaigns/Heir_To_The_Throne/units/Battle_Princess.cfg
+++ b/data/campaigns/Heir_To_The_Throne/units/Battle_Princess.cfg
@@ -7,6 +7,7 @@
     num_traits=0
     image="units/human-battleprincess-resting.png"
     {LEADING_ANIM "units/human-battleprincess-leading-1.png" "units/human-battleprincess-leading-2.png" 22,-22}
+    {INITIATIVE_ANIM "units/human-battleprincess-leading-1.png" "units/human-battleprincess-leading-2.png"}
     hitpoints=62
     movement_type=smallfoot
     [resistance]

--- a/data/campaigns/Heir_To_The_Throne/units/Princess.cfg
+++ b/data/campaigns/Heir_To_The_Throne/units/Princess.cfg
@@ -8,6 +8,7 @@
     image="units/human-princess.png"
     {DEFENSE_ANIM "units/human-princess-defend-2.png" "units/human-princess-defend-1.png" {SOUND_LIST:HUMAN_FEMALE_HIT} }
     {LEADING_ANIM "units/human-princess-leading-2.png" "units/human-princess-leading-1.png" 22,-22}
+    {INITIATIVE_ANIM "units/human-princess-leading-2.png" "units/human-princess-leading-1.png"}
     hitpoints=48
     movement_type=smallfoot
     [resistance]

--- a/data/campaigns/Heir_To_The_Throne/utils/abilities.cfg
+++ b/data/campaigns/Heir_To_The_Throne/utils/abilities.cfg
@@ -15,10 +15,41 @@
         [affect_adjacent]
         [/affect_adjacent]
     [/firststrike]
+    [firststrike]
+        id=initiative_anim
+        affect_self=no
+        affect_allies=yes
+        active_on=defense
+        [filter_student]
+            [filter_weapon]
+                special_id_active=initiative
+            [/filter_weapon]
+        [/filter_student]
+        [affect_adjacent]
+        [/affect_adjacent]
+    [/firststrike]
 #enddef
 
 #define NOTE_INITIATIVE
     [special_note]
         note=_"This unit’s grasp of melee tactics allows adjacent allies to strike the first blow even when defending."
     [/special_note]
+#enddef
+
+#define INITIATIVE_ANIM FULL_IMAGE HALFWAYS_IMAGE
+    [leading_anim]
+        [filter_attack]
+            special_id_active=initiative_anim
+            [not]
+                special_type_active=leadership
+            [/not]
+            [not]
+                special_id_active=firststrike
+            [/not]
+        [/filter_attack]
+        start_time=-126
+        [frame]
+            image={HALFWAYS_IMAGE}:1,{FULL_IMAGE}:250,{HALFWAYS_IMAGE}:1
+        [/frame]
+    [/leading_anim]
 #enddef

--- a/data/core/macros/animation-utils.cfg
+++ b/data/core/macros/animation-utils.cfg
@@ -25,18 +25,41 @@
     # Define an animation of a unit waving/raising their weapon,
     # with a gleam of light reflecting off it at the point specified by
     # OFFSET_POSITION
-    [leading_anim]
-        start_time=-126
-        [frame]
-            image={HALFWAYS_IMAGE}:1,{FULL_IMAGE}:250,{HALFWAYS_IMAGE}:1
-        [/frame]
+    {LEADING_ANIM_FILTER {FULL_IMAGE} {HALFWAYS_IMAGE} {OFFSET_POSITION} special_type_active=leadership}
+#enddef
 
-        halo_start_time=-100
-        [halo_frame]
-            halo="halo/misc/leadership-flare-[1~13].png:20"
-            halo_x,halo_y={OFFSET_POSITION}
-        [/halo_frame]
+#define LEADING_ANIM_FILTER FULL_IMAGE HALFWAYS_IMAGE OFFSET_POSITION ATTACK
+    # Define an animation of a unit waving/raising their weapon,
+    # with a gleam of light reflecting off it at the point specified by
+    # OFFSET_POSITION
+    [leading_anim]
+        [filter_attack]
+            {ATTACK}
+        [/filter_attack]
+        {LEADING_BASE {FULL_IMAGE} {HALFWAYS_IMAGE} {OFFSET_POSITION}}
     [/leading_anim]
+#enddef
+
+#define HELPING_ANIM FULL_IMAGE HALFWAYS_IMAGE OFFSET_POSITION
+    # Define an animation of a unit waving/raising their weapon,
+    # with a gleam of light reflecting off it at the point specified by
+    # OFFSET_POSITION
+    [resistance_anim]
+        {LEADING_BASE {FULL_IMAGE} {HALFWAYS_IMAGE} {OFFSET_POSITION}}
+    [/resistance_anim]
+#enddef
+
+#define LEADING_BASE FULL_IMAGE HALFWAYS_IMAGE OFFSET_POSITION
+    start_time=-126
+    [frame]
+        image={HALFWAYS_IMAGE}:1,{FULL_IMAGE}:250,{HALFWAYS_IMAGE}:1
+    [/frame]
+
+    halo_start_time=-100
+    [halo_frame]
+        halo="halo/misc/leadership-flare-[1~13].png:20"
+        halo_x,halo_y={OFFSET_POSITION}
+    [/halo_frame]
 #enddef
 
 #define DEFENSE_ANIM REACTION_IMAGE BASE_IMAGE HIT_SOUND

--- a/src/units/udisplay.cpp
+++ b/src/units/udisplay.cpp
@@ -657,10 +657,16 @@ void unit_attack(display * disp, game_board & board,
 
 	animator.add_animation(defender.shared_from_this(), defender_anim, def->get_location(), true, text, {255, 0, 0});
 
-	for(const unit_ability& ability : attacker.get_abilities_weapons("leadership", weapon, secondary_attack)) {
+	static const std::vector<std::string> leader_tags{"damage", "chance_to_hit", "berserk", "swarm", "drains", "heal_on_hit", "plague", "slow", "petrifies", "firststrike", "poison"};
+	unit_ability_list abilities = attacker.get_abilities_weapons("leadership", weapon, secondary_attack);
+	for(auto& special : leader_tags) {
+		abilities.append(weapon->list_ability(special));
+	}
+	for(const unit_ability& ability : abilities) {
 		if(ability.teacher_loc == a) {
 			continue;
 		}
+
 		if(ability.teacher_loc == b) {
 			continue;
 		}
@@ -724,8 +730,13 @@ void reset_helpers(const unit *attacker,const unit *defender)
 {
 	display* disp = display::get_singleton();
 	const unit_map& units = disp->get_units();
+	static const std::vector<std::string> leader_tags{"damage", "chance_to_hit", "berserk", "swarm", "drains", "heal_on_hit", "plague", "slow", "petrifies", "firststrike", "poison"};
 	if(attacker) {
-		for(const unit_ability& ability : attacker->get_abilities("leadership")) {
+		unit_ability_list attacker_abilities = attacker->get_abilities("leadership");
+		for(auto& special : leader_tags) {
+			attacker_abilities.append(attacker->get_abilities(special));
+		}
+		for(const unit_ability& ability : attacker_abilities) {
 			unit_map::const_iterator leader = units.find(ability.teacher_loc);
 			assert(leader != units.end());
 			leader->anim_comp().set_standing();
@@ -733,7 +744,11 @@ void reset_helpers(const unit *attacker,const unit *defender)
 	}
 
 	if(defender) {
-		for(const unit_ability& ability : defender->get_abilities("resistance")) {
+		unit_ability_list defender_abilities = defender->get_abilities("resistance");
+		for(auto& special : leader_tags) {
+			defender_abilities.append(defender->get_abilities(special));
+		}
+		for(const unit_ability& ability : defender_abilities) {
 			unit_map::const_iterator helper = units.find(ability.teacher_loc);
 			assert(helper != units.end());
 			helper->anim_comp().set_standing();


### PR DESCRIPTION
the calling of same [leading_anim] by the abilities of diffrent tags inside same unit_type don't cause problem. this is the fact of insert two leading_anim different inside same unit_type who cause bugs but this is no specifical to my PR, the same preoblem appear alos when one o f [leading_anim] have [filter_attack]range=range and other don't have filter_attack, then if unit under_leadership use ranged attack, two [leading_anim] called in same times, and you will see alternate of one and other naimation for leader.